### PR TITLE
Fix config injection and script path

### DIFF
--- a/resources/views/Extensions/IO/Head.twig
+++ b/resources/views/Extensions/IO/Head.twig
@@ -1,7 +1,7 @@
 {# Inject plugin configuration into window object #}
 <script>
-  window.pluginDynamicPlaceholderConfig = {{ pluginConfig('DynamicSearchPlaceholders')|json_encode|raw }};
+  window.dynamicSearchPlaceholderConfig = {{ pluginConfig('DynamicSearchPlaceholders')|json_encode|raw }};
 </script>
 
 {# Load the plugin’s JavaScript file #}
-<script src="{{ plugin_path('DynamicSearchPlaceholders') ~ '/js/dynamicPlaceholder.js' }}"></script>
+<script src="{{ plugin_path('DynamicSearchPlaceholders') ~ '/js/dynamic-placeholder.js' }}"></script>


### PR DESCRIPTION
## Summary
- ensure JS config is assigned to `dynamicSearchPlaceholderConfig` expected by script
- correct JS filename to match actual `dynamic-placeholder.js`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890988fa4948331a5732ed00d312bed